### PR TITLE
preserve-metadata

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -36,23 +36,23 @@ type Archive interface {
 
 // FromFormat determines which archive to use from given archive format.
 func FromFormat(logger log.Logger, root string, format string, opts ...Option) Archive {
-	options := options{
-		compressionLevel: DefaultCompressionLevel,
-	}
+    options := options{
+        compressionLevel: DefaultCompressionLevel,
+    }
 
 	for _, o := range opts {
 		o.apply(&options)
 	}
 
-	switch format {
-	case Gzip:
-		return gzip.New(logger, root, options.skipSymlinks, options.compressionLevel)
-	case Zstd:
-		return zstd.New(logger, root, options.skipSymlinks, options.compressionLevel)
-	case Tar:
-		return tar.New(logger, root, options.skipSymlinks)
-	default:
-		level.Error(logger).Log("msg", "unknown archive format", "format", format)
-		return tar.New(logger, root, options.skipSymlinks) // DefaultArchiveFormat
-	}
+    switch format {
+    case Gzip:
+        return gzip.NewWithPreserve(logger, root, options.skipSymlinks, options.compressionLevel, options.preserveMetadata)
+    case Zstd:
+        return zstd.NewWithPreserve(logger, root, options.skipSymlinks, options.compressionLevel, options.preserveMetadata)
+    case Tar:
+        return tar.NewWithPreserve(logger, root, options.skipSymlinks, options.preserveMetadata)
+    default:
+        level.Error(logger).Log("msg", "unknown archive format", "format", format)
+        return tar.NewWithPreserve(logger, root, options.skipSymlinks, options.preserveMetadata) // DefaultArchiveFormat
+    }
 }

--- a/archive/gzip/gzip.go
+++ b/archive/gzip/gzip.go
@@ -13,16 +13,22 @@ import (
 
 // Archive implements archive for gzip.
 type Archive struct {
-	logger log.Logger
+    logger log.Logger
 
-	root             string
-	compressionLevel int
-	skipSymlinks     bool
+    root             string
+    compressionLevel int
+    skipSymlinks     bool
+    preserveMeta     bool
 }
 
 // New creates an archive that uses the .tar.gz file format.
 func New(logger log.Logger, root string, skipSymlinks bool, compressionLevel int) *Archive {
-	return &Archive{logger, root, compressionLevel, skipSymlinks}
+    return &Archive{logger: logger, root: root, compressionLevel: compressionLevel, skipSymlinks: skipSymlinks}
+}
+
+// NewWithPreserve creates a gzip archive with metadata preservation setting.
+func NewWithPreserve(logger log.Logger, root string, skipSymlinks bool, compressionLevel int, preserve bool) *Archive {
+    return &Archive{logger: logger, root: root, compressionLevel: compressionLevel, skipSymlinks: skipSymlinks, preserveMeta: preserve}
 }
 
 // Create writes content of the given source to an archive, returns written bytes.
@@ -36,7 +42,7 @@ func (a *Archive) Create(srcs []string, w io.Writer, isRelativePath bool) (int64
 
 	defer internal.CloseWithErrLogf(a.logger, gw, "gzip writer")
 
-	return tar.New(a.logger, a.root, a.skipSymlinks).Create(srcs, gw, isRelativePath)
+    return tar.NewWithPreserve(a.logger, a.root, a.skipSymlinks, a.preserveMeta).Create(srcs, gw, isRelativePath)
 }
 
 // Extract reads content from the given archive reader and restores it to the destination, returns written bytes.
@@ -48,5 +54,5 @@ func (a *Archive) Extract(dst string, r io.Reader) (int64, error) {
 
 	defer internal.CloseWithErrLogf(a.logger, gr, "gzip reader")
 
-	return tar.New(a.logger, a.root, a.skipSymlinks).Extract(dst, gr)
+    return tar.NewWithPreserve(a.logger, a.root, a.skipSymlinks, a.preserveMeta).Extract(dst, gr)
 }

--- a/archive/option.go
+++ b/archive/option.go
@@ -1,8 +1,9 @@
 package archive
 
 type options struct {
-	compressionLevel int
-	skipSymlinks     bool
+    compressionLevel int
+    skipSymlinks     bool
+    preserveMetadata bool
 }
 
 // Option overrides behavior of Archive.
@@ -18,14 +19,21 @@ func (f optionFunc) apply(o *options) {
 
 // WithCompressionLevel sets compression level option.
 func WithCompressionLevel(i int) Option {
-	return optionFunc(func(o *options) {
-		o.compressionLevel = i
-	})
+    return optionFunc(func(o *options) {
+        o.compressionLevel = i
+    })
 }
 
 // WithSkipSymlinks sets skip symlink option.
 func WithSkipSymlinks(b bool) Option {
-	return optionFunc(func(o *options) {
-		o.skipSymlinks = b
-	})
+    return optionFunc(func(o *options) {
+        o.skipSymlinks = b
+    })
+}
+
+// WithPreserveMetadata enables metadata preservation in tar streams (mode, timestamps, and ownership where supported).
+func WithPreserveMetadata(b bool) Option {
+    return optionFunc(func(o *options) {
+        o.preserveMetadata = b
+    })
 }

--- a/archive/tar/ownership_unix.go
+++ b/archive/tar/ownership_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package tar
+
+import (
+    "os"
+    "syscall"
+)
+
+// getOwnership extracts uid/gid from FileInfo on Unix platforms.
+func getOwnership(fi os.FileInfo) (int, int, bool) {
+    if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+        return int(stat.Uid), int(stat.Gid), true
+    }
+    return 0, 0, false
+}
+
+// chown best-effort sets ownership; ignore errors at call sites.
+func chown(path string, uid, gid int) error {
+    // If uid/gid are zero and not desired, still attempt; caller ignores EPERM.
+    return os.Chown(path, uid, gid)
+}
+
+// lchown best-effort sets ownership on a symlink.
+func lchown(path string, uid, gid int) error {
+    return os.Lchown(path, uid, gid)
+}
+

--- a/archive/tar/ownership_windows.go
+++ b/archive/tar/ownership_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package tar
+
+import "os"
+
+// On Windows, POSIX ownership is not applicable.
+func getOwnership(fi os.FileInfo) (int, int, bool) { return 0, 0, false }
+func chown(path string, uid, gid int) error        { return nil }
+func lchown(path string, uid, gid int) error       { return nil }
+

--- a/archive/tar/tar_preserve_test.go
+++ b/archive/tar/tar_preserve_test.go
@@ -1,0 +1,134 @@
+package tar
+
+import (
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "runtime"
+    "testing"
+    "time"
+
+    "github.com/go-kit/kit/log"
+    "github.com/meltwater/drone-cache/test"
+)
+
+// Test that when preserve is enabled, file mode and times are restored (best-effort across OS).
+func TestPreserveMetadata_FileModeAndTimes(t *testing.T) {
+    test.Ok(t, os.MkdirAll(testRootMounted, 0755))
+    test.Ok(t, os.MkdirAll(testRootExtracted, 0755))
+
+    // Create a temp dir with one file whose mode/times we control.
+    srcDir, cleanup := test.CreateTempDir(t, "preserve_file_meta_src", testRootMounted)
+    t.Cleanup(cleanup)
+
+    filePath := filepath.Join(srcDir, "file.txt")
+    content := []byte("hello metadata\n")
+    test.Ok(t, ioutil.WriteFile(filePath, content, 0640))
+
+    // Set a known mtime (truncate to seconds for portability) and atime same as mtime
+    wantTime := time.Now().Add(-7 * time.Minute).Truncate(time.Second)
+    test.Ok(t, os.Chtimes(filePath, wantTime, wantTime))
+
+    // Create tar with preservation enabled
+    ta := NewWithPreserve(log.NewNopLogger(), testRootMounted, true, true)
+    arcDir, arcCleanup := test.CreateTempDir(t, "preserve_file_meta_arc", testRootMounted)
+    t.Cleanup(arcCleanup)
+    archivePath := filepath.Join(arcDir, "preserve_file_meta.tar")
+
+    written, err := create(ta, []string{srcDir}, archivePath)
+    test.Ok(t, err)
+    test.Assert(t, written > 0, "expected some bytes written")
+
+    // Remove source to ensure we read from archive
+    test.Ok(t, os.RemoveAll(srcDir))
+
+    // Extract
+    dstDir, dstCleanup := test.CreateTempDir(t, "preserve_file_meta_dst", testRootExtracted)
+    t.Cleanup(dstCleanup)
+    _, err = extract(ta, archivePath, dstDir)
+    test.Ok(t, err)
+
+    // Validate restored file metadata
+    restored := filepath.Join(dstDir, filepath.Base(srcDir), "file.txt")
+    st, err := os.Stat(restored)
+    test.Ok(t, err)
+    if runtime.GOOS != "windows" {
+        // Mode check only meaningful on Unix-like systems
+        // Mask to permission bits
+        got := st.Mode().Perm()
+        want := os.FileMode(0640)
+        test.Equals(t, got, want)
+    }
+    // ModTime should be close to wantTime (allow small delta)
+    if dt := st.ModTime().Sub(wantTime); dt < -2*time.Second || dt > 2*time.Second {
+        t.Fatalf("modtime delta too large: got=%v want=%v", st.ModTime(), wantTime)
+    }
+}
+
+// Test that directory times are restored after extraction completes (delayed restore).
+func TestPreserveMetadata_DirectoryTimesDelayed(t *testing.T) {
+    test.Ok(t, os.MkdirAll(testRootMounted, 0755))
+    test.Ok(t, os.MkdirAll(testRootExtracted, 0755))
+
+    // Create a nested structure
+    srcDir, cleanup := test.CreateTempDir(t, "preserve_dir_meta_src", testRootMounted)
+    t.Cleanup(cleanup)
+    nested := filepath.Join(srcDir, "nested")
+    test.Ok(t, os.MkdirAll(nested, 0755))
+    nf := filepath.Join(nested, "f.txt")
+    test.Ok(t, ioutil.WriteFile(nf, []byte("x"), 0644))
+
+    // Set dir mtime
+    wantDirTime := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+    test.Ok(t, os.Chtimes(nested, wantDirTime, wantDirTime))
+
+    ta := NewWithPreserve(log.NewNopLogger(), testRootMounted, true, true)
+    arcDir, arcCleanup := test.CreateTempDir(t, "preserve_dir_meta_arc", testRootMounted)
+    t.Cleanup(arcCleanup)
+    archivePath := filepath.Join(arcDir, "preserve_dir_meta.tar")
+    _, err := create(ta, []string{srcDir}, archivePath)
+    test.Ok(t, err)
+
+    dstDir, dstCleanup := test.CreateTempDir(t, "preserve_dir_meta_dst", testRootExtracted)
+    t.Cleanup(dstCleanup)
+    _, err = extract(ta, archivePath, dstDir)
+    test.Ok(t, err)
+
+    restoredDir := filepath.Join(dstDir, filepath.Base(srcDir), "nested")
+    st, err := os.Stat(restoredDir)
+    test.Ok(t, err)
+    if dt := st.ModTime().Sub(wantDirTime); dt < -2*time.Second || dt > 2*time.Second {
+        t.Fatalf("dir modtime delta too large: got=%v want=%v", st.ModTime(), wantDirTime)
+    }
+}
+
+// Test that enabling preserve on restore still works with archives created without preservation.
+func TestPreserveMetadata_OldArchiveGraceful(t *testing.T) {
+    test.Ok(t, os.MkdirAll(testRootMounted, 0755))
+    test.Ok(t, os.MkdirAll(testRootExtracted, 0755))
+
+    // Create a simple archive with preservation disabled
+    srcs := exampleFileTree(t, "preserve_old_archive_src", testRootMounted)
+    taNoPreserve := New(log.NewNopLogger(), testRootMounted, true)
+    arcDir, arcCleanup := test.CreateTempDir(t, "preserve_old_archive_arc", testRootMounted)
+    t.Cleanup(arcCleanup)
+    archivePath := filepath.Join(arcDir, "old_archive.tar")
+    _, err := create(taNoPreserve, srcs, archivePath)
+    test.Ok(t, err)
+
+    // Extract with preservation enabled; should not fail
+    taPreserve := NewWithPreserve(log.NewNopLogger(), testRootMounted, true, true)
+    dstDir, dstCleanup := test.CreateTempDir(t, "preserve_old_archive_dst", testRootExtracted)
+    t.Cleanup(dstCleanup)
+    _, err = extract(taPreserve, archivePath, dstDir)
+    test.Ok(t, err)
+
+    // Basic content equality still holds
+    var relativeSrcs []string
+    for _, s := range srcs {
+        if !filepath.IsAbs(s) {
+            relativeSrcs = append(relativeSrcs, s)
+        }
+    }
+    test.EqualDirs(t, dstDir, testRootMounted, relativeSrcs)
+}

--- a/archive/tar/times_darwin.go
+++ b/archive/tar/times_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package tar
+
+import (
+    "os"
+    "syscall"
+    "time"
+)
+
+// extractAtime obtains the last access time from FileInfo on Darwin.
+func extractAtime(fi os.FileInfo) (time.Time, bool) {
+    if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+        return time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec)), true
+    }
+    return time.Time{}, false
+}
+

--- a/archive/tar/times_linux.go
+++ b/archive/tar/times_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package tar
+
+import (
+    "os"
+    "syscall"
+    "time"
+)
+
+// extractAtime obtains the last access time from FileInfo on Linux.
+func extractAtime(fi os.FileInfo) (time.Time, bool) {
+    if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+        return time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)), true
+    }
+    return time.Time{}, false
+}
+

--- a/archive/tar/times_windows.go
+++ b/archive/tar/times_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tar
+
+import (
+    "os"
+    "time"
+)
+
+// On Windows, access time retrieval varies; skip and rely on ModTime.
+func extractAtime(fi os.FileInfo) (time.Time, bool) { return time.Time{}, false }
+

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -13,13 +13,14 @@ import (
 
 // Config plugin-specific parameters and secrets.
 type Config struct {
-	ArchiveFormat    string
-	Backend          string
-	CacheKeyTemplate string
-	MetricsFile      string
-	RemoteRoot       string
-	LocalRoot        string
-	AccountID        string
+    ArchiveFormat    string
+    Backend          string
+    CacheKeyTemplate string
+    MetricsFile      string
+    RemoteRoot       string
+    LocalRoot        string
+    AccountID        string
+    PreserveMetadata bool
 
 	// Modes
 	Debug               bool
@@ -29,13 +30,13 @@ type Config struct {
 	AutoDetectEarlyExit bool
 
 	// Optional
-	SkipSymlinks               bool
-	Override                   bool
-	FailRestoreIfKeyNotPresent bool
-	CompressionLevel           int
-	StorageOperationTimeout    time.Duration
-	EnableCacheKeySeparator    bool
-	StrictKeyMatching          bool `envconfig:"PLUGIN_STRICT_KEY_MATCHING" default:"true"`
+    SkipSymlinks               bool
+    Override                   bool
+    FailRestoreIfKeyNotPresent bool
+    CompressionLevel           int
+    StorageOperationTimeout    time.Duration
+    EnableCacheKeySeparator    bool
+    StrictKeyMatching          bool `envconfig:"PLUGIN_STRICT_KEY_MATCHING" default:"true"`
 
 	Mount []string
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -185,11 +185,15 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	}
 
 	// 3. Initialize cache.
+	// Enable metadata preservation only for supported backends when requested.
+	shouldPreserve := cfg.PreserveMetadata && (cfg.Backend == backend.S3 || cfg.Backend == backend.GCS)
+
 	c := cache.New(p.logger,
 		storage.New(p.logger, b, cfg.StorageOperationTimeout),
 		archive.FromFormat(p.logger, localRoot, cfg.ArchiveFormat,
 			archive.WithSkipSymlinks(cfg.SkipSymlinks),
 			archive.WithCompressionLevel(cfg.CompressionLevel),
+			archive.WithPreserveMetadata(shouldPreserve),
 		),
 		generator,
 		cfg.Backend,

--- a/main.go
+++ b/main.go
@@ -344,6 +344,14 @@ func main() {
 			EnvVars: []string{"PLUGIN_STRICT_KEY_MATCHING"},
 		},
 
+		// Metadata preservation (opt-in)
+		&cli.BoolFlag{
+			Name:    "preserve-metadata",
+			Usage:   "Preserve file metadata (permissions, timestamps, ownership where supported) in archive (S3/GCS only)",
+			Value:   false,
+			EnvVars: []string{"PLUGIN_PRESERVE_METADATA"},
+		},
+
 		// Backends Configs
 
 		// Shared Config flags
@@ -666,6 +674,7 @@ func run(c *cli.Context) error {
 		FailRestoreIfKeyNotPresent: c.Bool("fail-restore-if-key-not-present"),
 		EnableCacheKeySeparator:    c.Bool("enable-cache-key-separator"),
 		StrictKeyMatching:          c.Bool("strict-key-matching"),
+        PreserveMetadata:           c.Bool("preserve-metadata"),
 
 		StorageOperationTimeout: c.Duration("backend.operation-timeout"),
 		FileSystem: filesystem.Config{


### PR DESCRIPTION
What Changed

- CLI/config:
    - Added --preserve-metadata (env PLUGIN_PRESERVE_METADATA) to enable metadata-aware archiving.
    - Plumbed PreserveMetadata into plugin.Config and wired it into the plugin runtime.
    - Plumbed PreserveMetadata into plugin.Config and wired it into the plugin runtime.
-
Backend gating:
    - Only turns on metadata preservation for backend == "s3" or backend == "gcs" when the flag is true. For all others, behavior unchanged.
-
Archive options:
    - Added archive.WithPreserveMetadata(bool) to pass intent to the tar layer (used transparently for tar/gzip/zstd).
-
Tar implementation (Go-only, no external tar):
    - New helper constructors while preserving old API:
    - `tar.New(logger, root, skipSymlinks bool)` unchanged (default behavior).
    - `tar.NewWithPreserve(..., preserve bool)` opt‑in path.
- When enabled on Create:
    - Sets PAX format headers and writes best‑effort metadata:
      - Mode always, AccessTime (if retrievable), and UID/GID on Unix.
- When enabled on Extract:
    - Applies chmod and Chtimes for files; best‑effort chown (Unix) ignoring failures.
    - For directories, delays restoring mode/times/ownership until extraction completes (deepest-first).
    - For symlinks, best‑effort lchown on Unix.
    - All metadata ops are best‑effort and never fail the restore; old tarballs without metadata are handled gracefully.

- Gzip/zstd wrappers:
    - Kept existing New(...) signatures backward compatible (tests instantiate these directly).
    - Added NewWithPreserve used by the archive.FromFormat factory.
    - Propagates preserve flag to tar.NewWithPreserve.
    - Propagates preserve flag to tar.NewWithPreserve.
-
Internal plumbing:
    - archive/archive.go extended to pass WithPreserveMetadata and use NewWithPreserve constructors.
-
New OS-specific helpers:
    - archive/tar/times_linux.go, times_darwin.go, times_windows.go retrieve AccessTime where feasible (no-op on Windows).
    - archive/tar/ownership_unix.go, ownership_windows.go implement best‑effort chown/lchown on Unix and no-ops on Windows.

Files changed

- main.go: added CLI flag and passed config
- internal/plugin/config.go: added PreserveMetadata
- internal/plugin/plugin.go: gated WithPreserveMetadata for S3/GCS
- archive/option.go: added preserveMetadata + option
- archive/archive.go: passed the new option and constructors
- archive/tar/tar.go: implemented create/extract preservation, delayed dir fixes
- archive/tar/{times_.go,ownership_.go}: OS-specific helpers
- archive/gzip/gzip.go + archive/zstd/zstd.go: added NewWithPreserve, kept old New

Notes on behavior and safety

- Backward compatible: default is false; existing flows unchanged.
- Graceful fallback: missing metadata or permission failures (e.g., chown without root, FS limitations) are ignored and do not break restore.
- Windows: ownership ops are no-ops; still preserves chmod best‑effort and timestamps via os.Chtimes.
- Compression (gzip/zstd): unaffected; metadata is inside the tar layer.