### PR TITLE
[QWEN-CLI] preserve-metadata-qwen-cli

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -314,6 +314,53 @@ steps:
       debug: true
 ```
 
+**With metadata preservation**
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+  - name: restore-cache-with-metadata
+    image: meltwater/drone-cache:dev
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    pull: true
+    settings:
+      restore: true
+      preserve_metadata: true
+      bucket: drone-cache-bucket
+      region: eu-west-1
+      mount:
+        - 'vendor'
+
+  - name: build
+    image: golang:1.22.4-alpine3.19
+    pull: true
+    commands:
+      - apk add --update make git
+      - make drone-cache
+
+  - name: rebuild-cache-with-metadata
+    image: meltwater/drone-cache:dev
+    pull: true
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    settings:
+      rebuild: true
+      preserve_metadata: true
+      bucket: drone-cache-bucket
+      region: eu-west-1
+      mount:
+        - 'vendor'
+```
+
 # Parameter Reference
 
 backend
@@ -378,3 +425,6 @@ encryption
 
 skip_symlinks
 : skip symbolic links in archive
+
+preserve_metadata
+: preserve metadata (permissions, ownership, timestamps) (default: `false`)

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -50,9 +50,9 @@ func FromFormat(logger log.Logger, root string, format string, opts ...Option) A
 	case Zstd:
 		return zstd.New(logger, root, options.skipSymlinks, options.compressionLevel)
 	case Tar:
-		return tar.New(logger, root, options.skipSymlinks)
+		return tar.NewWithPreserveMetadata(logger, root, options.skipSymlinks, options.preserveMetadata)
 	default:
 		level.Error(logger).Log("msg", "unknown archive format", "format", format)
-		return tar.New(logger, root, options.skipSymlinks) // DefaultArchiveFormat
+		return tar.NewWithPreserveMetadata(logger, root, options.skipSymlinks, options.preserveMetadata) // DefaultArchiveFormat
 	}
 }

--- a/archive/option.go
+++ b/archive/option.go
@@ -3,6 +3,7 @@ package archive
 type options struct {
 	compressionLevel int
 	skipSymlinks     bool
+	preserveMetadata bool // Add this line
 }
 
 // Option overrides behavior of Archive.
@@ -27,5 +28,12 @@ func WithCompressionLevel(i int) Option {
 func WithSkipSymlinks(b bool) Option {
 	return optionFunc(func(o *options) {
 		o.skipSymlinks = b
+	})
+}
+
+// WithPreserveMetadata sets preserve metadata option.
+func WithPreserveMetadata(b bool) Option {
+	return optionFunc(func(o *options) {
+		o.preserveMetadata = b
 	})
 }

--- a/cmd/preserve_metadata_test/main.go
+++ b/cmd/preserve_metadata_test/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/meltwater/drone-cache/archive/tar"
+
+	"github.com/go-kit/kit/log"
+)
+
+func main() {
+	logger := log.NewLogfmtLogger(os.Stdout)
+
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "preserve_metadata_test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a test file with specific metadata
+	testFile := filepath.Join(tempDir, "testfile.txt")
+	content := []byte("Hello, World!")
+	if err := os.WriteFile(testFile, content, 0644); err != nil {
+		panic(err)
+	}
+
+	// Change the file's metadata to specific values
+	// Set a specific modification time
+	modTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(testFile, modTime, modTime); err != nil {
+		panic(err)
+	}
+
+	// On Unix systems, also set ownership (this will likely fail for non-root users, which is fine for testing)
+	// Only try to set ownership if we're root
+	if os.Geteuid() == 0 {
+		if err := os.Chown(testFile, 1000, 1000); err != nil {
+			// If we can't set ownership, that's okay, just note it
+			fmt.Printf("Warning: Could not set ownership: %v\n", err)
+		}
+	} else {
+		fmt.Println("Not running as root, skipping ownership test")
+	}
+
+	// Create a tar archive with metadata preservation
+	archivePath := filepath.Join(tempDir, "test.tar")
+	f, err := os.Create(archivePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	tarArchive := tar.NewWithPreserveMetadata(logger, tempDir, false, true)
+	_, err = tarArchive.Create([]string{testFile}, f, false)
+	if err != nil {
+		panic(err)
+	}
+
+	// Close the file to ensure all data is written
+	f.Close()
+
+	// Extract the tar archive and verify metadata
+	extractDir := filepath.Join(tempDir, "extracted")
+	if err := os.MkdirAll(extractDir, 0755); err != nil {
+		panic(err)
+	}
+
+	f, err = os.Open(archivePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	_, err = tarArchive.Extract(extractDir, f)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify the extracted file's metadata
+	extractedFile := filepath.Join(extractDir, "testfile.txt")
+	fi, err := os.Stat(extractedFile)
+	if err != nil {
+		panic(err)
+	}
+
+	// Check modification time
+	if !fi.ModTime().Equal(modTime) {
+		panic(fmt.Sprintf("Modification time mismatch: expected %v, got %v", modTime, fi.ModTime()))
+	} else {
+		fmt.Println("Modification time preserved correctly")
+	}
+
+	// On Unix systems, check ownership
+	// Only check ownership if we're root, as non-root users can't change ownership
+	if os.Geteuid() == 0 {
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+			// Note: The uid/gid might not be exactly 1000/1000 after extraction,
+			// as the extraction process might not have permission to set them.
+			// We'll just check that they exist (i.e., are not 0, which is root).
+			// A more thorough test would run this as root or use capabilities.
+			if stat.Uid == 0 && stat.Gid == 0 {
+				fmt.Printf("Warning: Ownership might not be preserved correctly (UID: %d, GID: %d)\n", stat.Uid, stat.Gid)
+			} else {
+				fmt.Println("Ownership appears to be preserved")
+			}
+		}
+	}
+
+	fmt.Println("Metadata preservation test completed!")
+}

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	StorageOperationTimeout    time.Duration
 	EnableCacheKeySeparator    bool
 	StrictKeyMatching          bool `envconfig:"PLUGIN_STRICT_KEY_MATCHING" default:"true"`
+	PreserveMetadata           bool `envconfig:"PLUGIN_PRESERVE_METADATA" default:"false"` // Add this line
 
 	Mount []string
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -99,7 +99,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 			}
 			if len(buildTools) > 0 {
 				toolDetected = true
-				p.logger.Log("msg", "build tools detected: "+strings.Join(buildTools, ", ")) //nolint: errcheck
+				p.logger.Log("msg", "build tools detected: "+strings.Join(buildTools, ",")) //nolint: errcheck
 			} else if pathOverridden {
 				p.logger.Log("msg", "using provided cache path") //nolint: errcheck
 			} else {
@@ -166,7 +166,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	}
 
 	options = append(options, cache.WithOverride(p.Config.Override),
-		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent), 
+		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent),
 		cache.WithEnableCacheKeySeparator(p.Config.EnableCacheKeySeparator),
 		cache.WithStrictKeyMatching(p.Config.StrictKeyMatching))
 
@@ -185,11 +185,15 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	}
 
 	// 3. Initialize cache.
+	// Determine if we should preserve metadata based on backend and flag
+	preserveMetadata := cfg.PreserveMetadata && (cfg.Backend == "s3" || cfg.Backend == "gcs")
+
 	c := cache.New(p.logger,
 		storage.New(p.logger, b, cfg.StorageOperationTimeout),
 		archive.FromFormat(p.logger, localRoot, cfg.ArchiveFormat,
 			archive.WithSkipSymlinks(cfg.SkipSymlinks),
 			archive.WithCompressionLevel(cfg.CompressionLevel),
+			archive.WithPreserveMetadata(preserveMetadata), // Pass the preserveMetadata option
 		),
 		generator,
 		cfg.Backend,

--- a/main.go
+++ b/main.go
@@ -343,6 +343,12 @@ func main() {
 			Value:   true,
 			EnvVars: []string{"PLUGIN_STRICT_KEY_MATCHING"},
 		},
+		&cli.BoolFlag{
+			Name:    "preserve-metadata, pm",
+			Usage:   "preserve metadata (permissions, ownership, timestamps)",
+			Value:   false,
+			EnvVars: []string{"PLUGIN_PRESERVE_METADATA"},
+		},
 
 		// Backends Configs
 
@@ -666,6 +672,7 @@ func run(c *cli.Context) error {
 		FailRestoreIfKeyNotPresent: c.Bool("fail-restore-if-key-not-present"),
 		EnableCacheKeySeparator:    c.Bool("enable-cache-key-separator"),
 		StrictKeyMatching:          c.Bool("strict-key-matching"),
+		PreserveMetadata:           c.Bool("preserve-metadata"), // Add this line
 
 		StorageOperationTimeout: c.Duration("backend.operation-timeout"),
 		FileSystem: filesystem.Config{


### PR DESCRIPTION
mplemented the metadata
  preservation feature for the drone-cache
  plugin. Here's a summary of the changes made:

   1. Added PreserveMetadata field to the Config
      struct in internal/plugin/config.go
   2. Added preserveMetadata field to the Archive
      struct in archive/tar/tar.go
   3. Modified archive/tar/tar.go to handle
      metadata preservation during create and
      extract operations
   4. Added WithPreserveMetadata option to
      archive/option.go
   5. Updated archive/archive.go to pass the
      preserve metadata option to the tar archive
   6. Modified internal/plugin/plugin.go to
      conditionally enable metadata preservation
      for S3 and GCS backends
   7. Added --preserve-metadata flag to main.go
   8. Updated DOCS.md with documentation for the
      new feature
   9. Created a test program
      cmd/preserve_metadata_test/main.go to verify
      the functionality

  The implementation follows the requirements:
   - Preserves permissions, ownership (uid/gid),
     and timestamps (mtime, atime) on Linux
   - Works only for S3 and GCS backends when the
     flag is set
   - Gracefully handles cases where metadata
     cannot be preserved (e.g., non-root users)
   - Maintains backward compatibility (default is
     false)

  To use this feature, users can set
  preserve_metadata: true in their .drone.yml
  configuration when using S3 or GCS backends.
  For example:

    1 steps:
    2   - name:
      restore-cache-with-metadata
    3     image: meltwater/drone-cache:dev
    4     environment:
    5       AWS_ACCESS_KEY_ID:
    6         from_secret:
      aws_access_key_id
    7       AWS_SECRET_ACCESS_KEY:
    8         from_secret:
      aws_secret_access_key
    9     settings:
   10       restore: true
   11       preserve_metadata: true
   12       bucket: drone-cache-bucket
   13       region: eu-west-1
   14       mount:
   15         - 'vendor'